### PR TITLE
Add back dtype and merge single/double precision functions

### DIFF
--- a/src/FINUFFT.jl
+++ b/src/FINUFFT.jl
@@ -122,25 +122,23 @@ const nufft_c_opts = nufft_opts # backward compability
 Return a [`nufft_opts`](@ref) struct with the default FINUFFT settings. Set up the double precision variant by default.\\
 See: <https://finufft.readthedocs.io/en/latest/usage.html#options>
 """
-finufft_default_opts() = finufft_default_opts(nufft_opts{Float64}())
+function finufft_default_opts(dtype::DataType=Float64)
+    opts = nufft_opts{dtype}()
 
-function finufft_default_opts(opts::nufft_opts{T}) where T <: Float64
+    if dtype==Float64
+        ccall( (:finufft_default_opts, libfinufft),
+               Nothing,
+               (Ref{nufft_opts},),
+               opts
+               )
 
-    ccall( (:finufft_default_opts, libfinufft),
-            Nothing,
-            (Ref{nufft_opts},),
-            opts
-            )
-
-    return opts
-end
-
-function finufft_default_opts(opts::nufft_opts{T}) where T <: Float32
-    ccall( (:finufftf_default_opts, libfinufft),
-            Nothing,
-            (Ref{nufft_opts},),
-            opts
-            )
+    else
+        ccall( (:finufftf_default_opts, libfinufft),
+               Nothing,
+               (Ref{nufft_opts},),
+               opts
+               )
+    end
 
     return opts
 end

--- a/src/guru.jl
+++ b/src/guru.jl
@@ -13,19 +13,19 @@ mutable struct finufft_plan{T}
     plan_ptr   :: finufft_plan_c
 end
 
-### Double precision
 function finufft_makeplan(type::Integer,
                           n_modes_or_dim::Union{Array{BIGINT},Integer},
                           iflag::Integer,
                           ntrans::Integer,
-                          eps::T;
-                          kwargs...) where T <: Float64
+                          eps::AbstractFloat;
+                          dtype=Float64,
+                          kwargs...)
 # see https://stackoverflow.com/questions/40140699/the-proper-way-to-declare-c-void-pointers-in-julia for how to declare c-void pointers in julia
 #   one can also use Array/Vector for cvoid pointer, Array and Ref both work
 #   plan_p = Array{finufft_plan_c}(undef,1)
     plan_p = Ref{finufft_plan_c}()
 
-    opts = finufft_default_opts(nufft_opts{T}())
+    opts = finufft_default_opts(dtype)
     setkwopts!(opts;kwargs...)
 
     n_modes = ones(BIGINT,3)
@@ -38,53 +38,24 @@ function finufft_makeplan(type::Integer,
         n_modes[1:dim] .= n_modes_or_dim
     end
 
-    ret = ccall( (:finufft_makeplan, libfinufft),
-                    Cint,
-                    (Cint,
-                    Cint,
-                    Ref{BIGINT},
-                    Cint,
-                    Cint,
-                    Cdouble,
-                    Ptr{finufft_plan_c},
-                    Ref{nufft_opts}),
-                    type,dim,n_modes,iflag,ntrans,eps,plan_p,opts
-                    )
-    
-    check_ret(ret)
+    if dtype==Float64
+        tol = Float64(eps)
+        ret = ccall( (:finufft_makeplan, libfinufft),
+                      Cint,
+                      (Cint,
+                       Cint,
+                       Ref{BIGINT},
+                       Cint,
+                       Cint,
+                       Cdouble,
+                       Ptr{finufft_plan_c},
+                       Ref{nufft_opts}),
+                      type,dim,n_modes,iflag,ntrans,tol,plan_p,opts
+                      )
 
-    ms = n_modes[1]
-    mt = n_modes[2]
-    mu = n_modes[3]
-    plan = finufft_plan{T}(type,ntrans,dim,ms,mt,mu,0,0,plan_p[])
-end
-
-### Single precision
-function finufft_makeplan(type::Integer,
-                          n_modes_or_dim::Union{Array{BIGINT},Integer},
-                          iflag::Integer,
-                          ntrans::Integer,
-                          eps::T;
-                          kwargs...) where T <: Float32
-# see https://stackoverflow.com/questions/40140699/the-proper-way-to-declare-c-void-pointers-in-julia for how to declare c-void pointers in julia
-#   one can also use Array/Vector for cvoid pointer, Array and Ref both work
-#   plan_p = Array{finufft_plan_c}(undef,1)
-    plan_p = Ref{finufft_plan_c}()
-
-    opts = finufft_default_opts(nufft_opts{T}())
-    setkwopts!(opts;kwargs...)
-
-    n_modes = ones(BIGINT,3)
-    if type==3
-        @assert ndims(n_modes_or_dim) == 0
-        dim = n_modes_or_dim
     else
-        @assert length(n_modes_or_dim)<=3 && length(n_modes_or_dim)>=1
-        dim = length(n_modes_or_dim)
-        n_modes[1:dim] .= n_modes_or_dim
-    end
-
-    ret = ccall( (:finufftf_makeplan, libfinufft),
+        tol = Float32(eps)
+        ret = ccall( (:finufftf_makeplan, libfinufft),
                       Cint,
                       (Cint,
                        Cint,
@@ -94,79 +65,66 @@ function finufft_makeplan(type::Integer,
                        Cfloat,
                        Ptr{finufft_plan_c},
                        Ref{nufft_opts}),
-                      type,dim,n_modes,iflag,ntrans,eps,plan_p,opts
+                      type,dim,n_modes,iflag,ntrans,tol,plan_p,opts
                       )
-
+    end
     check_ret(ret)
 
     ms = n_modes[1]
     mt = n_modes[2]
     mu = n_modes[3]
-    plan = finufft_plan{T}(type,ntrans,dim,ms,mt,mu,0,0,plan_p[])
+    plan = finufft_plan{dtype}(type,ntrans,dim,ms,mt,mu,0,0,plan_p[])
+    return plan
 end
 
-### Double precision
 function finufft_setpts(plan::finufft_plan{T},
                         xj::Array{T},
                         yj::Array{T}=T[],
                         zj::Array{T}=T[],
                         s::Array{T}=T[],
                         t::Array{T}=T[],
-                        u::Array{T}=T[]) where T <: Float64
+                        u::Array{T}=T[]) where T <: fftwReal
 
     (M, N) = valid_setpts(plan.type, plan.dim, xj, yj, zj, s, t, u)
 
     plan.nj = M
     plan.nk = N
 
-    ret = ccall( (:finufft_setpts, libfinufft),
-                    Cint,
-                    (finufft_plan_c,
-                    BIGINT,
-                    Ref{Cdouble},
-                    Ref{Cdouble},
-                    Ref{Cdouble},
-                    BIGINT,
-                    Ref{Cdouble},
-                    Ref{Cdouble},
-                    Ref{Cdouble}),
-                    plan.plan_ptr,M,xj,yj,zj,N,s,t,u
-                    )
+    if T==Float64
+        T_real = Array{Float64}
+        ret = ccall( (:finufft_setpts, libfinufft),
+                     Cint,
+                     (finufft_plan_c,
+                      BIGINT,
+                      Ref{Cdouble},
+                      Ref{Cdouble},
+                      Ref{Cdouble},
+                      BIGINT,
+                      Ref{Cdouble},
+                      Ref{Cdouble},
+                      Ref{Cdouble}),
+                     plan.plan_ptr,M,T_real(xj),T_real(yj),T_real(zj),N,T_real(s),T_real(t),T_real(u)
+                     )
+    else
+        T_real = Array{Float32}
+        ret = ccall( (:finufftf_setpts, libfinufft),
+                     Cint,
+                     (finufft_plan_c,
+                      BIGINT,
+                      Ref{Cfloat},
+                      Ref{Cfloat},
+                      Ref{Cfloat},
+                      BIGINT,
+                      Ref{Cfloat},
+                      Ref{Cfloat},
+                      Ref{Cfloat}),
+                     plan.plan_ptr,M,T_real(xj),T_real(yj),T_real(zj),N,T_real(s),T_real(t),T_real(u)
+                     )
+    end
+
     check_ret(ret)
     return ret
 end
-
-### Single precision
-function finufft_setpts(plan::finufft_plan{T},
-                        xj::Array{T},
-                        yj::Array{T}=T[],
-                        zj::Array{T}=T[],
-                        s::Array{T}=T[],
-                        t::Array{T}=T[],
-                        u::Array{T}=T[]) where T <: Float32
-
-    (M, N) = valid_setpts(plan.type, plan.dim, xj, yj, zj, s, t, u)
-
-    plan.nj = M
-    plan.nk = N
-
-    ret = ccall( (:finufftf_setpts, libfinufft),
-                    Cint,
-                    (finufft_plan_c,
-                    BIGINT,
-                    Ref{Cfloat},
-                    Ref{Cfloat},
-                    Ref{Cfloat},
-                    BIGINT,
-                    Ref{Cfloat},
-                    Ref{Cfloat},
-                    Ref{Cfloat}),
-                    plan.plan_ptr,M,xj,yj,zj,N,s,t,u
-                    )
-    check_ret(ret)
-    return ret
-end
-
 
 function finufft_exec(plan::finufft_plan{T},
                       input::Array{Complex{T}}) where T <: fftwReal
@@ -202,106 +160,27 @@ function finufft_exec(plan::finufft_plan{T},
     return output
 end
 
-function finufft_destroy(plan::finufft_plan{T}) where T <: Float64
-    ret = ccall( (:finufft_destroy, libfinufft),
-                 Cint,
-                 (finufft_plan_c,),
-                 plan.plan_ptr
-                 )
-    check_ret(ret)
-    return ret
-end
-
-function finufft_destroy(plan::finufft_plan{T}) where T <: Float32
-    ret = ccall( (:finufftf_destroy, libfinufft),
-                    Cint,
-                    (finufft_plan_c,),
-                    plan.plan_ptr
-                    )
-    check_ret(ret)
-    return ret
-end
-
-### Double precision
-function finufft_exec!(plan::finufft_plan{T},
-                      input::Array{Complex{T}},
-                      output::Array{Complex{T}}) where T <: Float64
-    type = plan.type
-    ntrans = plan.ntrans
-    dim = plan.dim
-    n_modes = Array{BIGINT}(undef,3)
-    n_modes[1] = plan.ms
-    n_modes[2] = plan.mt
-    n_modes[3] = plan.mu
-    if type==1
-        if dim==1
-            if ntrans==1
-                @assert size(output)==(n_modes[1],) || size(output)==(n_modes[1],ntrans)
-            else
-                @assert size(output)==(n_modes[1],ntrans)
-            end
-        elseif dim==2
-            if ntrans==1
-                @assert size(output)==(n_modes[1],n_modes[2]) || size(output)==(n_modes[1],n_modes[2],ntrans)
-            else
-                @assert size(output)==(n_modes[1],n_modes[2],ntrans)
-            end
-        elseif dim==3
-            if ntrans==1
-                @assert size(output)==(n_modes[1],n_modes[2],n_modes[3]) || size(output)==(n_modes[1],n_modes[2],n_modes[3],ntrans)
-            else
-                @assert size(output)==(n_modes[1],n_modes[2],n_modes[3],ntrans)
-            end
-        else
-            ret = ERR_DIM_NOTVALID
-            check_ret(ret)
-        end
-        ret = ccall( (:finufft_execute, libfinufft),
-                        Cint,
-                        (finufft_plan_c,
-                        Ref{ComplexF64},
-                        Ref{ComplexF64}),
-                        plan.plan_ptr,input,output
-                        )
-    elseif type==2
-        nj = plan.nj
-        if ntrans==1
-            @assert size(output)==(nj,ntrans) || size(output)==(nj,)
-        else
-            @assert size(output)==(nj,ntrans)
-        end
-        ret = ccall( (:finufft_execute, libfinufft),
-                        Cint,
-                        (finufft_plan_c,
-                        Ref{ComplexF64},
-                        Ref{ComplexF64}),
-                        plan.plan_ptr,output,input
-                        )
-    elseif type==3
-        nk = plan.nk
-        if ntrans==1
-            @assert size(output)==(nk,ntrans) || size(output)==(nk,)
-        else
-            @assert size(output)==(nk,ntrans)
-        end
-        ret = ccall( (:finufft_execute, libfinufft),
-                        Cint,
-                        (finufft_plan_c,
-                        Ref{ComplexF64},
-                        Ref{ComplexF64}),
-                        plan.plan_ptr,input,output
-                        )
+function finufft_destroy(plan::finufft_plan{T}) where T <: fftwReal
+    if T==Float64
+        ret = ccall( (:finufft_destroy, libfinufft),
+                     Cint,
+                     (finufft_plan_c,),
+                     plan.plan_ptr
+                     )
     else
-        ret = ERR_TYPE_NOTVALID
+        ret = ccall( (:finufftf_destroy, libfinufft),
+                     Cint,
+                     (finufft_plan_c,),
+                     plan.plan_ptr
+                     )
     end
     check_ret(ret)
+    return ret
 end
 
-
-### Single precision
 function finufft_exec!(plan::finufft_plan{T},
                       input::Array{Complex{T}},
-                      output::Array{Complex{T}}) where T <: Float32
+                      output::Array{Complex{T}}) where T <: fftwReal
     type = plan.type
     ntrans = plan.ntrans
     dim = plan.dim
@@ -332,13 +211,23 @@ function finufft_exec!(plan::finufft_plan{T},
             ret = ERR_DIM_NOTVALID
             check_ret(ret)
         end
-        ret = ccall( (:finufftf_execute, libfinufft),
-                        Cint,
-                        (finufft_plan_c,
-                        Ref{ComplexF32},
-                        Ref{ComplexF32}),
-                        plan.plan_ptr,input,output
-                        )
+        if T==Float64
+            ret = ccall( (:finufft_execute, libfinufft),
+                         Cint,
+                         (finufft_plan_c,
+                          Ref{ComplexF64},
+                          Ref{ComplexF64}),
+                         plan.plan_ptr,input,output
+                         )
+        else
+            ret = ccall( (:finufftf_execute, libfinufft),
+                         Cint,
+                         (finufft_plan_c,
+                          Ref{ComplexF32},
+                          Ref{ComplexF32}),
+                         plan.plan_ptr,input,output
+                         )
+        end
     elseif type==2
         nj = plan.nj
         if ntrans==1
@@ -346,13 +235,23 @@ function finufft_exec!(plan::finufft_plan{T},
         else
             @assert size(output)==(nj,ntrans)
         end
-        ret = ccall( (:finufftf_execute, libfinufft),
-                        Cint,
-                        (finufft_plan_c,
-                        Ref{ComplexF32},
-                        Ref{ComplexF32}),
-                        plan.plan_ptr,output,input
-                        )
+        if T==Float64
+            ret = ccall( (:finufft_execute, libfinufft),
+                         Cint,
+                         (finufft_plan_c,
+                          Ref{ComplexF64},
+                          Ref{ComplexF64}),
+                         plan.plan_ptr,output,input
+                         )
+        else
+            ret = ccall( (:finufftf_execute, libfinufft),
+                         Cint,
+                         (finufft_plan_c,
+                          Ref{ComplexF32},
+                          Ref{ComplexF32}),
+                         plan.plan_ptr,output,input
+                         )
+        end
     elseif type==3
         nk = plan.nk
         if ntrans==1
@@ -360,13 +259,23 @@ function finufft_exec!(plan::finufft_plan{T},
         else
             @assert size(output)==(nk,ntrans)
         end
-        ret = ccall( (:finufftf_execute, libfinufft),
-                        Cint,
-                        (finufft_plan_c,
-                        Ref{ComplexF32},
-                        Ref{ComplexF32}),
-                        plan.plan_ptr,input,output
-                        )
+        if T==Float64
+            ret = ccall( (:finufft_execute, libfinufft),
+                         Cint,
+                         (finufft_plan_c,
+                          Ref{ComplexF64},
+                          Ref{ComplexF64}),
+                         plan.plan_ptr,input,output
+                         )
+        else
+            ret = ccall( (:finufftf_execute, libfinufft),
+                         Cint,
+                         (finufft_plan_c,
+                          Ref{ComplexF32},
+                          Ref{ComplexF32}),
+                         plan.plan_ptr,input,output
+                         )
+        end
     else
         ret = ERR_TYPE_NOTVALID
     end

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -23,17 +23,17 @@ function nufft1d1(xj::Array{T},
     valid_setpts(1,1,xj)
     ntrans = valid_ntr(xj,cj)
     fk = Array{Complex{T}}(undef, ms, ntrans)
-    # checkkwdtype(T; kwargs...)
-    nufft1d1!(xj, cj, iflag, eps, fk; kwargs...)
+    checkkwdtype(T; kwargs...)
+    nufft1d1!(xj, cj, iflag, eps, fk; kwargs...,dtype=T)
     return fk
 end
 
 """
-    nufft2d1(xj      :: Array{Float64}, 
-             yj      :: Array{Float64}, 
-             cj      :: Array{ComplexF64}, 
+    nufft2d1(xj      :: Array{Float64} or Array{Float32}
+             yj      :: Array{Float64} or Array{Float32}, 
+             cj      :: Array{ComplexF64} or Array{ComplexF32}, 
              iflag   :: Integer, 
-             eps     :: Float64,
+             eps     :: Float64 or Float32,
              ms      :: Integer,
              mt      :: Integer;
              kwargs...
@@ -52,18 +52,18 @@ function nufft2d1(xj      :: Array{T},
     valid_setpts(1,2,xj,yj)
     ntrans = valid_ntr(xj,cj)
     fk = Array{Complex{T}}(undef, ms, mt, ntrans)
-    # checkkwdtype(T; kwargs...)
-    nufft2d1!(xj, yj, cj, iflag, eps, fk;kwargs...)
+    checkkwdtype(T; kwargs...)
+    nufft2d1!(xj, yj, cj, iflag, eps, fk;kwargs...,dtype=T)
     return fk
 end
 
 """
-    nufft3d1(xj      :: Array{Float64}, 
-             yj      :: Array{Float64}, 
-             zj      :: Array{Float64}, 
-             cj      :: Array{ComplexF64}, 
+    nufft3d1(xj      :: Array{Float64} or Array{Float32}, 
+             yj      :: Array{Float64} or Array{Float32}, 
+             zj      :: Array{Float64} or Array{Float32}, 
+             cj      :: Array{ComplexF64} or Array{ComplexF32}, 
              iflag   :: Integer, 
-             eps     :: Float64,
+             eps     :: Float64 or Float32,
              ms      :: Integer,
              mt      :: Integer,
              mu      :: Integer;
@@ -85,8 +85,8 @@ function nufft3d1(xj      :: Array{T},
     valid_setpts(1,3,xj,yj,zj)
     ntrans = valid_ntr(xj,cj)
     fk = Array{Complex{T}}(undef, ms, mt, mu, ntrans)
-    # checkkwdtype(T; kwargs...)
-    nufft3d1!(xj, yj, zj, cj, iflag, eps, fk;kwargs...)
+    checkkwdtype(T; kwargs...)
+    nufft3d1!(xj, yj, zj, cj, iflag, eps, fk;kwargs...,dtype=T)
     return fk
 end
 
@@ -94,10 +94,10 @@ end
 ## Type-2
 
 """
-    nufft1d2(xj      :: Array{Float64}, 
+    nufft1d2(xj      :: Array{Float64} or Array{Float32}, 
              iflag   :: Integer, 
-             eps     :: Float64,
-             fk      :: Array{ComplexF64};
+             eps     :: Float64 or Float32,
+             fk      :: Array{ComplexF64} or Array{ComplexF32};
              kwargs...
             ) -> Array{ComplexF64}
 
@@ -111,17 +111,17 @@ function nufft1d2(xj      :: Array{T},
     (nj, nk) = valid_setpts(2,1,xj)
     (ms, ntrans) = get_nmodes_from_fk(1,fk)
     cj = Array{Complex{T}}(undef, nj, ntrans)
-    # checkkwdtype(T; kwargs...)
-    nufft1d2!(xj, cj, iflag, eps, fk;kwargs...)
+    checkkwdtype(T; kwargs...)
+    nufft1d2!(xj, cj, iflag, eps, fk;kwargs...,dtype=T)
     return cj
 end
 
 """
-    nufft2d2(xj      :: Array{Float64}, 
-             yj      :: Array{Float64}, 
+    nufft2d2(xj      :: Array{Float64} or Array{Float32}, 
+             yj      :: Array{Float64} or Array{Float32}, 
              iflag   :: Integer, 
-             eps     :: Float64,
-             fk      :: Array{ComplexF64};
+             eps     :: Float64 or Float32,
+             fk      :: Array{ComplexF64} or Array{ComplexF32};
              kwargs...
             ) -> Array{ComplexF64}
 
@@ -136,18 +136,18 @@ function nufft2d2(xj      :: Array{T},
     (nj, nk) = valid_setpts(2,2,xj,yj)
     (ms, mt, ntrans) = get_nmodes_from_fk(2,fk)
     cj = Array{Complex{T}}(undef, nj, ntrans)
-    # checkkwdtype(T; kwargs...)
-    nufft2d2!(xj, yj, cj, iflag, eps, fk;kwargs...)
+    checkkwdtype(T; kwargs...)
+    nufft2d2!(xj, yj, cj, iflag, eps, fk;kwargs...,dtype=T)
     return cj
 end
 
 """
-    nufft3d2(xj      :: Array{Float64}, 
-             yj      :: Array{Float64}, 
-             zj      :: Array{Float64}, 
+    nufft3d2(xj      :: Array{Float64} or Array{Float32}, 
+             yj      :: Array{Float64} or Array{Float32}, 
+             zj      :: Array{Float64} or Array{Float32}, 
              iflag   :: Integer, 
-             eps     :: Float64,
-             fk      :: Array{ComplexF64};
+             eps     :: Float64 or Float32,
+             fk      :: Array{ComplexF64} or Array{ComplexF32};
              kwargs...
             ) -> Array{ComplexF64}
 
@@ -163,8 +163,8 @@ function nufft3d2(xj      :: Array{T},
     (nj, nk) = valid_setpts(2,3,xj,yj,zj)
     (ms, mt, mu, ntrans) = get_nmodes_from_fk(3,fk)
     cj = Array{Complex{T}}(undef, nj, ntrans)
-    # checkkwdtype(T; kwargs...)
-    nufft3d2!(xj, yj, zj, cj, iflag, eps, fk;kwargs...)
+    checkkwdtype(T; kwargs...)
+    nufft3d2!(xj, yj, zj, cj, iflag, eps, fk;kwargs...,dtype=T)
     return cj
 end
 
@@ -172,11 +172,11 @@ end
 ## Type-3
 
 """
-    nufft1d3(xj      :: Array{Float64}, 
-             cj      :: Array{ComplexF64}, 
+    nufft1d3(xj      :: Array{Float64} or Array{Float32}, 
+             cj      :: Array{ComplexF64} or Array{ComplexF32}, 
              iflag   :: Integer, 
-             eps     :: Float64,
-             sk      :: Array{Float64};
+             eps     :: Float64 or Float32,
+             sk      :: Array{Float64} or Array{Float32};
              kwargs...
             ) -> Array{ComplexF64}
 
@@ -191,19 +191,19 @@ function nufft1d3(xj      :: Array{T},
     (nj, nk) = valid_setpts(3,1,xj,T[],T[],sk)
     ntrans = valid_ntr(xj,cj)
     fk = Array{Complex{T}}(undef, nk, ntrans)
-    # checkkwdtype(T; kwargs...)
-    nufft1d3!(xj, cj, iflag, eps, sk, fk;kwargs...)
+    checkkwdtype(T; kwargs...)
+    nufft1d3!(xj, cj, iflag, eps, sk, fk;kwargs...,dtype=T)
     return fk
 end
 
 """
-    nufft2d3(xj      :: Array{Float64}, 
-             yj      :: Array{Float64},
-             cj      :: Array{ComplexF64}, 
+    nufft2d3(xj      :: Array{Float64} or Array{Float32}, 
+             yj      :: Array{Float64} or Array{Float32},
+             cj      :: Array{ComplexF64} or Array{ComplexF32}, 
              iflag   :: Integer, 
-             eps     :: Float64,
-             sk      :: Array{Float64},
-             tk      :: Array{Float64};
+             eps     :: Float64 or Float32,
+             sk      :: Array{Float64} or Array{Float32},
+             tk      :: Array{Float64} or Array{Float32};
              kwargs...
             ) -> Array{ComplexF64}
 
@@ -220,21 +220,21 @@ function nufft2d3(xj      :: Array{T},
     (nj, nk) = valid_setpts(3,2,xj,yj,T[],sk,tk)
     ntrans = valid_ntr(xj,cj)
     fk = Array{Complex{T}}(undef, nk, ntrans)
-    # checkkwdtype(T; kwargs...)
-    nufft2d3!(xj, yj, cj, iflag, eps, sk, tk, fk;kwargs...)
+    checkkwdtype(T; kwargs...)
+    nufft2d3!(xj, yj, cj, iflag, eps, sk, tk, fk;kwargs...,dtype=T)
     return fk
 end
 
 """
-    nufft3d3(xj      :: Array{Float64}, 
-             yj      :: Array{Float64},
-             zj      :: Array{Float64},
-             cj      :: Array{ComplexF64}, 
+    nufft3d3(xj      :: Array{Float64} or Array{Float32}, 
+             yj      :: Array{Float64} or Array{Float32},
+             zj      :: Array{Float64} or Array{Float32},
+             cj      :: Array{ComplexF64} or Array{ComplexF32}, 
              iflag   :: Integer, 
-             eps     :: Float64,
-             sk      :: Array{Float64},
-             tk      :: Array{Float64},
-             uk      :: Array{Float64};
+             eps     :: Float64 or Float32,
+             sk      :: Array{Float64} or Array{Float32},
+             tk      :: Array{Float64} or Array{Float32},
+             uk      :: Array{Float64} or Array{Float32};
              kwargs...
             ) -> Array{ComplexF64}
 
@@ -253,8 +253,8 @@ function nufft3d3(xj      :: Array{T},
     (nj, nk) = valid_setpts(3,3,xj,yj,zj,sk,tk,uk)
     ntrans = valid_ntr(xj,cj)
     fk = Array{Complex{T}}(undef, nk, ntrans)
-    # checkkwdtype(T; kwargs...)
-    nufft3d3!(xj, yj, zj, cj, iflag, eps, sk, tk, uk, fk;kwargs...)
+    checkkwdtype(T; kwargs...)
+    nufft3d3!(xj, yj, zj, cj, iflag, eps, sk, tk, uk, fk;kwargs...,dtype=T)
     return fk
 end
 
@@ -264,11 +264,11 @@ end
 ## 1D
 
 """
-    nufft1d1!(xj      :: Array{Float64}, 
-              cj      :: Array{ComplexF64}, 
+    nufft1d1!(xj      :: Array{Float64} or Array{Float32}, 
+              cj      :: Array{ComplexF64} or Array{ComplexF32}, 
               iflag   :: Integer, 
-              eps     :: Float64,
-              fk      :: Array{ComplexF64};
+              eps     :: Float64 or Float32,
+              fk      :: Array{ComplexF64} or Array{ComplexF32};
               kwargs...
             )
 
@@ -284,7 +284,7 @@ function nufft1d1!(xj      :: Array{T},
     ntrans = valid_ntr(xj,cj)
     (ms, ntrans_fk) = get_nmodes_from_fk(1,fk)
 
-    # checkkwdtype(T; kwargs...)
+    checkkwdtype(T; kwargs...)
     plan = finufft_makeplan(1,[ms;],iflag,ntrans,eps;kwargs...)
     finufft_setpts(plan,xj)
     finufft_exec!(plan,cj,fk)
@@ -294,11 +294,11 @@ end
 
 
 """
-    nufft1d2!(xj      :: Array{Float64}, 
-              cj      :: Array{ComplexF64}, 
+    nufft1d2!(xj      :: Array{Float64} or Array{Float32}, 
+              cj      :: Array{ComplexF64} or Array{ComplexF32}, 
               iflag   :: Integer, 
-              eps     :: Float64,
-              fk      :: Array{ComplexF64};
+              eps     :: Float64 or Float32,
+              fk      :: Array{ComplexF64} or Array{ComplexF32};
               kwargs...
             )
 
@@ -313,7 +313,7 @@ function nufft1d2!(xj      :: Array{T},
     (nj, nk) = valid_setpts(2,1,xj)
     (ms, ntrans) = get_nmodes_from_fk(1,fk)
 
-    # checkkwdtype(T; kwargs...)
+    checkkwdtype(T; kwargs...)
     plan = finufft_makeplan(2,[ms;],iflag,ntrans,eps;kwargs...)
     finufft_setpts(plan,xj)
     finufft_exec!(plan,fk,cj)
@@ -323,12 +323,12 @@ end
 
 
 """
-    nufft1d3!(xj      :: Array{Float64}, 
-              cj      :: Array{ComplexF64}, 
+    nufft1d3!(xj      :: Array{Float64} or Array{Float32}, 
+              cj      :: Array{ComplexF64} or Array{ComplexF32}, 
               iflag   :: Integer, 
-              eps     :: Float64,
-              sk      :: Array{Float64},
-              fk      :: Array{ComplexF64};
+              eps     :: Float64 or Float32,
+              sk      :: Array{Float64} or Array{Float32},
+              fk      :: Array{ComplexF64} or Array{ComplexF32};
               kwargs...
              )
 
@@ -344,7 +344,7 @@ function nufft1d3!(xj      :: Array{T},
     (nj, nk) = valid_setpts(3,1,xj,T[],T[],sk)
     ntrans = valid_ntr(xj,cj)
 
-    # checkkwdtype(T; kwargs...)
+    checkkwdtype(T; kwargs...)
     plan = finufft_makeplan(3,1,iflag,ntrans,eps;kwargs...)
     finufft_setpts(plan,xj,T[],T[],sk)
     finufft_exec!(plan,cj,fk)
@@ -356,12 +356,12 @@ end
 ## 2D
 
 """
-    nufft2d1!(xj      :: Array{Float64}, 
-              yj      :: Array{Float64}, 
-              cj      :: Array{ComplexF64}, 
+    nufft2d1!(xj      :: Array{Float64} or Array{Float32}, 
+              yj      :: Array{Float64} or Array{Float32}, 
+              cj      :: Array{ComplexF64} or Array{ComplexF32}, 
               iflag   :: Integer, 
-              eps     :: Float64,
-              fk      :: Array{ComplexF64};
+              eps     :: Float64 or Float32,
+              fk      :: Array{ComplexF64} or Array{ComplexF32};
               kwargs...
             )
 
@@ -379,7 +379,7 @@ function nufft2d1!(xj      :: Array{T},
     (ms, mt, ntrans_fk) = get_nmodes_from_fk(2,fk)
     @assert ntrans==ntrans_fk
 
-    # checkkwdtype(T; kwargs...)
+    checkkwdtype(T; kwargs...)
     plan = finufft_makeplan(1,[ms;mt],iflag,ntrans,eps;kwargs...)
     finufft_setpts(plan,xj,yj)
     finufft_exec!(plan,cj,fk)
@@ -389,12 +389,12 @@ end
 
 
 """
-    nufft2d2!(xj      :: Array{Float64}, 
-              yj      :: Array{Float64}, 
-              cj      :: Array{ComplexF64}, 
+    nufft2d2!(xj      :: Array{Float64} or Array{Float32}, 
+              yj      :: Array{Float64} or Array{Float32}, 
+              cj      :: Array{ComplexF64} or Array{ComplexF32}, 
               iflag   :: Integer, 
-              eps     :: Float64,
-              fk      :: Array{ComplexF64};
+              eps     :: Float64 or Float32,
+              fk      :: Array{ComplexF64} or Array{ComplexF32};
               kwargs...
             )
 
@@ -410,7 +410,7 @@ function nufft2d2!(xj      :: Array{T},
     (nj, nk) = valid_setpts(1,2,xj,yj)
     (ms, mt, ntrans) = get_nmodes_from_fk(2,fk)
 
-    # checkkwdtype(T; kwargs...)
+    checkkwdtype(T; kwargs...)
     plan = finufft_makeplan(2,[ms;mt],iflag,ntrans,eps;kwargs...)
     finufft_setpts(plan,xj,yj)
     finufft_exec!(plan,fk,cj)
@@ -419,14 +419,14 @@ function nufft2d2!(xj      :: Array{T},
 end
 
 """
-    nufft2d3!(xj      :: Array{Float64}, 
-              yj      :: Array{Float64},
-              cj      :: Array{ComplexF64}, 
+    nufft2d3!(xj      :: Array{Float64} or Array{Float32}, 
+              yj      :: Array{Float64} or Array{Float32},
+              cj      :: Array{ComplexF64} or Array{ComplexF32}, 
               iflag   :: Integer, 
-              eps     :: Float64,
-              sk      :: Array{Float64},
-              tk      :: Array{Float64},
-              fk      :: Array{ComplexF64};
+              eps     :: Float64 or Float32,
+              sk      :: Array{Float64} or Array{Float32},
+              tk      :: Array{Float64} or Array{Float32},
+              fk      :: Array{ComplexF64} or Array{ComplexF32};
               kwargs...
              )
 
@@ -444,7 +444,7 @@ function nufft2d3!(xj      :: Array{T},
     (nj, nk) = valid_setpts(3,2,xj,yj,T[],sk,tk)
     ntrans = valid_ntr(xj,cj)
 
-    # checkkwdtype(T; kwargs...)
+    checkkwdtype(T; kwargs...)
     plan = finufft_makeplan(3,2,iflag,ntrans,eps;kwargs...)
     finufft_setpts(plan,xj,yj,T[],sk,tk)
     finufft_exec!(plan,cj,fk)
@@ -455,13 +455,13 @@ end
 ## 3D
 
 """
-    nufft3d1!(xj      :: Array{Float64}, 
-              yj      :: Array{Float64}, 
-              zj      :: Array{Float64}, 
-              cj      :: Array{ComplexF64}, 
+    nufft3d1!(xj      :: Array{Float64} or Array{Float32}, 
+              yj      :: Array{Float64} or Array{Float32}, 
+              zj      :: Array{Float64} or Array{Float32}, 
+              cj      :: Array{ComplexF64} or Array{ComplexF32}, 
               iflag   :: Integer, 
-              eps     :: Float64,
-              fk      :: Array{ComplexF64};
+              eps     :: Float64 or Float32,
+              fk      :: Array{ComplexF64} or Array{ComplexF32};
               kwargs...
             )
 
@@ -480,7 +480,7 @@ function nufft3d1!(xj      :: Array{T},
     (ms, mt, mu, ntrans_fk) = get_nmodes_from_fk(3,fk)
     @assert ntrans == ntrans_fk
 
-    # checkkwdtype(T; kwargs...)
+    checkkwdtype(T; kwargs...)
     plan = finufft_makeplan(1,[ms;mt;mu],iflag,ntrans,eps;kwargs...)
     finufft_setpts(plan,xj,yj,zj)
     finufft_exec!(plan,cj,fk)
@@ -489,13 +489,13 @@ function nufft3d1!(xj      :: Array{T},
 end
 
 """
-    nufft3d2!(xj      :: Array{Float64}, 
-              yj      :: Array{Float64}, 
-              zj      :: Array{Float64}, 
-              cj      :: Array{ComplexF64}, 
+    nufft3d2!(xj      :: Array{Float64} or Array{Float32}, 
+              yj      :: Array{Float64} or Array{Float32}, 
+              zj      :: Array{Float64} or Array{Float32}, 
+              cj      :: Array{ComplexF64} or Array{ComplexF32}, 
               iflag   :: Integer, 
-              eps     :: Float64,
-              fk      :: Array{ComplexF64};
+              eps     :: Float64 or Float32,
+              fk      :: Array{ComplexF64} or Array{ComplexF32};
               kwargs...
             )
 
@@ -512,7 +512,7 @@ function nufft3d2!(xj      :: Array{T},
     (nj, nk) = valid_setpts(2,3,xj,yj,zj)
     (ms, mt, mu, ntrans) = get_nmodes_from_fk(3,fk)
 
-    # checkkwdtype(T; kwargs...)
+    checkkwdtype(T; kwargs...)
     plan = finufft_makeplan(2,[ms;mt;mu],iflag,ntrans,eps;kwargs...)
     finufft_setpts(plan,xj,yj,zj)
     finufft_exec!(plan,fk,cj)
@@ -521,16 +521,16 @@ function nufft3d2!(xj      :: Array{T},
 end
 
 """
-    nufft3d3!(xj      :: Array{Float64}, 
-              yj      :: Array{Float64},
-              zj      :: Array{Float64},
-              cj      :: Array{ComplexF64}, 
+    nufft3d3!(xj      :: Array{Float64} or Array{Float32}, 
+              yj      :: Array{Float64} or Array{Float32},
+              zj      :: Array{Float64} or Array{Float32},
+              cj      :: Array{ComplexF64} or Array{ComplexF32}, 
               iflag   :: Integer, 
-              eps     :: Float64,
-              sk      :: Array{Float64},
-              tk      :: Array{Float64},
-              uk      :: Array{Float64},
-              fk      :: Array{ComplexF64};
+              eps     :: Float64 or Float32,
+              sk      :: Array{Float64} or Array{Float32},
+              tk      :: Array{Float64} or Array{Float32},
+              uk      :: Array{Float64} or Array{Float32},
+              fk      :: Array{ComplexF64} or Array{ComplexF32};
               kwargs...
              )
 


### PR DESCRIPTION
This pull request add back to dtype to choose precision for makeplan instead of using eps. Also single/double functions are merge to one function. @ahbarnett you may want to review the pull request, thanks!